### PR TITLE
add 'unmatch_silent' to configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Format 'ltsv'(Labeled-TSV (Tab separated values)) is also supported:
 
 About LTSV, see: http://ltsv.org/
 
-If you want to suppress 'pattern not match' log, specify 'unmatch_silent true' to configuration.
+If you want to suppress 'pattern not match' log, specify 'suppress_parse_error_log true' to configuration.
 default value is false.
 
     <match in.hogelog>
@@ -75,7 +75,7 @@ default value is false.
       tag hogelog
       format /^col1=(?<col1>.+) col2=(?<col2>.+)$/
       key_name message
-      unmatch_silent true
+      suppress_parse_error_log true
     </match>
 
 

--- a/lib/fluent/plugin/fixed_parser.rb
+++ b/lib/fluent/plugin/fixed_parser.rb
@@ -8,7 +8,7 @@ class FluentExt::TextParser
     include Fluent::Configurable
 
     config_param :time_format, :string, :default => nil
-    config_param :unmatch_silent, :bool, :default => false
+    config_param :suppress_parse_error_log, :bool, :default => false
 
     def initialize(regexp, conf={})
       super()
@@ -21,7 +21,7 @@ class FluentExt::TextParser
     def call(text)
       m = @regexp.match(text)
       unless m
-        unless @unmatch_silent
+        unless @suppress_parse_error_log
           $log.warn "pattern not match: #{text}"
         end
 
@@ -74,7 +74,7 @@ class FluentExt::TextParser
       record = Yajl.load(text)
       return parse_time(record)
     rescue Yajl::ParseError
-      unless @unmatch_silent
+      unless @suppress_parse_error_log
         $log.warn "pattern not match(json): #{text.inspect}: #{$!}"
       end
 
@@ -129,7 +129,7 @@ class FluentExt::TextParser
     def call(text)
       m = REGEXP.match(text)
       unless m
-        unless @unmatch_silent
+        unless @suppress_parse_error_log
           $log.warn "pattern not match: #{text.inspect}"
         end
 


### PR DESCRIPTION
Hi, I add new optional configuration 'unmatch silent' to fluent-plugin-parser.

'unmatch_silent' is optional configuration that suppress 'pattern not match' log.
default value is 'false' (it means show 'pattern not match' log)

user can choose output 'pattern not match' to log or not.
for example, if it is known that the message does not match the pattern.

if this update is OK, please merge.

I wrote description to blog in japanese.
http://d.hatena.ne.jp/reiki4040/20130220/1361372494
