### PR TITLE
ConfigError should be prefixed with Fluent:: in fixed_parser.rb

### DIFF
--- a/lib/fluent/plugin/fixed_parser.rb
+++ b/lib/fluent/plugin/fixed_parser.rb
@@ -228,7 +228,7 @@ class FluentExt::TextParser
       # built-in template
       factory = TEMPLATE_FACTORIES[format]
       unless factory
-        raise ConfigError, "Unknown format template '#{format}'"
+        raise Fluent::ConfigError, "Unknown format template '#{format}'"
       end
       @parser = factory.call
 

--- a/test/plugin/test_out_parser.rb
+++ b/test/plugin/test_out_parser.rb
@@ -22,6 +22,13 @@ class ParserOutputTest < Test::Unit::TestCase
     assert_raise(Fluent::ConfigError) {
       d = create_driver('')
     }
+    assert_raise(Fluent::ConfigError) {
+      d = create_driver %[
+        tag foo.bar
+        format unknown_format_that_will_never_be_implemented
+        key_name foo
+      ]
+    }
     assert_nothing_raised {
       d = create_driver %[
         tag foo.bar


### PR DESCRIPTION
Otherwise, it's giving me a `NamedError`:

> NameError: uninitialized constant FluentExt::TextParser::ConfigError
