### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# fluent-plugin-parser, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-parser
 
 ## Component
 
 ### ParserOutput
 
-Parse string in log message, and re-emit.
+This is a [Fluentd](http://fluentd.org) plugin to parse strings in log messages
+and re-emit them.
 
 ### DeparserOutput
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
