### PR TITLE
Add option to prefix original attribute-pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ If you want original attribute-data pair in re-emitted message, specify 'reserve
       reserve_data yes
     </match>
 
+To prefix original attribute-data pair in re-emitted message, specify 'reserve_data_prefix':
+
+    <match raw.apache.*>
+      type parser
+      tag apache
+      format apache
+      key_name message
+      reserve_data yes
+      reserve_data_prefix @original:
+    </match>
+
 If you want to suppress 'pattern not match' log, specify 'suppress\_parse\_error\_log true' to configuration.
 default value is false.
 

--- a/lib/fluent/plugin/out_parser.rb
+++ b/lib/fluent/plugin/out_parser.rb
@@ -8,6 +8,7 @@ class Fluent::ParserOutput < Fluent::Output
   config_param :add_prefix, :string, :default => nil
   config_param :key_name, :string
   config_param :reserve_data, :bool, :default => false
+  config_param :reserve_data_prefix, :string, :default => nil
   config_param :inject_key_prefix, :string, :default => nil
   config_param :replace_invalid_sequence, :bool, :default => false
   config_param :hash_value_field, :string, :default => nil
@@ -109,6 +110,9 @@ class Fluent::ParserOutput < Fluent::Output
     end
     r = @hash_value_field ? {@hash_value_field => values} : values
     if @reserve_data
+      if @reserve_data_prefix
+        record = Hash[record.map{|k,v| [ @reserve_data_prefix + k, v ]}]
+      end
       r = r ? record.merge(r) : record
     end
     if r


### PR DESCRIPTION
This adds an option to prefix the existing record.

E.g., input like:
```{"message":"a:A b:B c:C","source":"xyz"}```

with config as:
```
type parser
format ltsv
reserve_data yes
reserve_data_prefix @
```

becomes
```
{
  "@message":"a:A b:B c:C",
  "@source":"xyz",
  "a":"A",
  "b":"B",
  "c":"C"
}
```