### PR TITLE
Add ignore_key_not_exist option to filter_parser.

### DIFF
--- a/fluent-plugin-parser.gemspec
+++ b/fluent-plugin-parser.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "test-unit"
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "oj"
   gem.add_runtime_dependency "fluentd", "~> 0.12.0"
 end

--- a/lib/fluent/plugin/filter_parser.rb
+++ b/lib/fluent/plugin/filter_parser.rb
@@ -37,8 +37,9 @@ class Fluent::ParserFilter < Fluent::Filter
     new_es = Fluent::MultiEventStream.new
     es.each do |time,record|
       raw_value = record[@key_name]
-      if raw_value.nil? and @ignore_key_not_exist
-        new_es.add(time, handle_parsed(tag, record, time, {}))
+      if raw_value.nil?
+        log.warn "#{@key_name} does not exist" unless @ignore_key_not_exist
+        new_es.add(time, handle_parsed(tag, record, time, {})) if @reserve_data
         next
       end
       begin
@@ -95,7 +96,7 @@ class Fluent::ParserFilter < Fluent::Filter
       values = Hash[values.map{|k,v| [ @inject_key_prefix + k, v ]}]
     end
     r = @hash_value_field ? {@hash_value_field => values} : values
-    if @reserve_data or @ignore_key_not_exist
+    if @reserve_data
       r = r ? record.merge(r) : record
     end
     r

--- a/lib/fluent/plugin/out_parser.rb
+++ b/lib/fluent/plugin/out_parser.rb
@@ -13,6 +13,7 @@ class Fluent::ParserOutput < Fluent::Output
   config_param :hash_value_field, :string, :default => nil
   config_param :suppress_parse_error_log, :bool, :default => false
   config_param :time_parse, :bool, :default => true
+  config_param :ignore_key_not_exist, :bool, default: false
 
   attr_reader :parser
 
@@ -73,6 +74,11 @@ class Fluent::ParserOutput < Fluent::Output
           end
     es.each do |time,record|
       raw_value = record[@key_name]
+      if raw_value.nil?
+        log.warn "#{@key_name} does not exist" unless @ignore_key_not_exist
+        handle_parsed(tag, record, time, {}) if @reserve_data
+        next
+      end
       begin
         @parser.parse(raw_value) do |t,values|
           if values

--- a/test/plugin/test_filter_parser.rb
+++ b/test/plugin/test_filter_parser.rb
@@ -550,18 +550,30 @@ class ParserFilterTest < Test::Unit::TestCase
   CONFIG_IGNORE = CONFIG_NOT_IGNORE + %[
     ignore_key_not_exist true
   ]
+  CONFIG_PASS_SAME_RECORD = CONFIG_IGNORE + %[
+    reserve_data true
+  ]
   def test_filter_key_not_exist
     d = create_driver(CONFIG_NOT_IGNORE, 'test.no.ignore')
-    assert_raise(ArgumentError) {
+    assert_nothing_raised {
       d.run do
         d.filter({'foo' => 'bar'}, Time.now.to_i)
       end
     }
+    assert_match /data does not exist/, d.instance.log.out.logs.first
 
     d = create_driver(CONFIG_IGNORE, 'test.ignore')
     assert_nothing_raised {
       d.run do
-        d.emit({'foo' => 'bar'}, Time.now.to_i)
+        d.filter({'foo' => 'bar'}, Time.now.to_i)
+      end
+    }
+    assert_not_match /data does not exist/, d.instance.log.out.logs.first
+
+    d = create_driver(CONFIG_PASS_SAME_RECORD, 'test.pass_same_record')
+    assert_nothing_raised {
+      d.run do
+        d.filter({'foo' => 'bar'}, Time.now.to_i)
       end
     }
     filtered = d.filtered_as_array


### PR DESCRIPTION
If 'key_name' doesn't exist, I got "ArgumentError parser io argument must be a String or respond to readpartial() or read()." from Oj.load(nil) at line45 `@parser.parse` .

Adding "oj" to gemspec may not be good idea, I couldn't catch up with any good idea about testing the case of "oj".

